### PR TITLE
update bimap implementation to reject result of leftFn, and improve type signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Standard Functions is a library aimed to fill in the gaps in the JS standard lib
 ## Functions
 
 <dl>
-<dt><a href="#bimap">bimap(leftFn, rightFn, p)</a> ⇒ <code>Promise.&lt;(T|never)&gt;</code></dt>
+<dt><a href="#bimap">bimap(leftFn, rightFn, p)</a> ⇒ <code>Promise.&lt;(R|never)&gt;</code></dt>
 <dd><p>Map over the success or error of a promise.</p>
 </dd>
 <dt><a href="#fmap">fmap(fn, p)</a> ⇒ <code>Promise.&lt;(T|never)&gt;</code></dt>
@@ -80,7 +80,7 @@ Works like the ! operator on the result of the function provided</p>
 
 <a name="bimap"></a>
 
-## bimap(leftFn, rightFn, p) ⇒ <code>Promise.&lt;(T\|never)&gt;</code>
+## bimap(leftFn, rightFn, p) ⇒ <code>Promise.&lt;(R\|never)&gt;</code>
 Map over the success or error of a promise.
 
 **Kind**: global function  
@@ -233,7 +233,8 @@ Call instance method of an object.
 <a name="negate"></a>
 
 ## negate(fn) ⇒ <code>function</code>
-Creates a function which negates the value of the result.Works like the ! operator on the result of the function provided
+Creates a function which negates the value of the result.
+Works like the ! operator on the result of the function provided
 
 **Kind**: global function  
 

--- a/async/bimap/bimap.js
+++ b/async/bimap/bimap.js
@@ -10,10 +10,10 @@ Object.defineProperty(exports, "__esModule", {
  * @param leftFn {Function}
  * @param rightFn {Function}
  * @param p {Promise<T | never>}
- * @returns {Promise<T | never>}
+ * @returns {Promise<R | never>}
  */
 function bimap(leftFn, rightFn, p) {
-  return p.then(rightFn, leftFn);
+  return p.then(rightFn, e => Promise.reject(leftFn(e)));
 }
 
 exports.default = bimap;

--- a/async/bimap/bimap.js.flow
+++ b/async/bimap/bimap.js.flow
@@ -5,14 +5,14 @@
  * @param leftFn {Function}
  * @param rightFn {Function}
  * @param p {Promise<T | never>}
- * @returns {Promise<T | never>}
+ * @returns {Promise<R | never>}
  */
-function bimap<T>(
-  leftFn: (Error) => any,
-  rightFn: (T) => any,
+function bimap<T, R, E>(
+  leftFn: (E) => any,
+  rightFn: (T) => R,
   p: Promise<T>
-): Promise<T> {
-  return p.then(rightFn, leftFn);
+): Promise<R> {
+  return p.then(rightFn, (e: E): Promise<R> => Promise.reject(leftFn(e)));
 }
 
 export default bimap;

--- a/core/index.js
+++ b/core/index.js
@@ -4,6 +4,24 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _always = require('./always/always');
+
+Object.defineProperty(exports, 'always', {
+  enumerable: true,
+  get: function () {
+    return _interopRequireDefault(_always).default;
+  }
+});
+
+var _and = require('./and/and');
+
+Object.defineProperty(exports, 'and', {
+  enumerable: true,
+  get: function () {
+    return _interopRequireDefault(_and).default;
+  }
+});
+
 var _compose = require('./compose/compose');
 
 Object.defineProperty(exports, 'compose', {
@@ -49,6 +67,42 @@ Object.defineProperty(exports, 'identity', {
   }
 });
 
+var _inst = require('./inst/inst');
+
+Object.defineProperty(exports, 'inst', {
+  enumerable: true,
+  get: function () {
+    return _interopRequireDefault(_inst).default;
+  }
+});
+
+var _negate = require('./negate/negate');
+
+Object.defineProperty(exports, 'negate', {
+  enumerable: true,
+  get: function () {
+    return _interopRequireDefault(_negate).default;
+  }
+});
+
+var _not = require('./not/not');
+
+Object.defineProperty(exports, 'not', {
+  enumerable: true,
+  get: function () {
+    return _interopRequireDefault(_not).default;
+  }
+});
+
+var _or = require('./or/or');
+
+Object.defineProperty(exports, 'or', {
+  enumerable: true,
+  get: function () {
+    return _interopRequireDefault(_or).default;
+  }
+});
+
 var _partial = require('./partial/partial');
 
 Object.defineProperty(exports, 'partial', {
@@ -64,6 +118,15 @@ Object.defineProperty(exports, 'partialRight', {
   enumerable: true,
   get: function () {
     return _interopRequireDefault(_partialRight).default;
+  }
+});
+
+var _trim = require('./trim/trim');
+
+Object.defineProperty(exports, 'trim', {
+  enumerable: true,
+  get: function () {
+    return _interopRequireDefault(_trim).default;
   }
 });
 

--- a/core/index.js.flow
+++ b/core/index.js.flow
@@ -1,9 +1,17 @@
 // @flow
 
+export { default as always } from './always/always';
+export { default as and } from './and/and';
 export { default as compose } from './compose/compose';
 export { default as composeRight } from './composeRight/composeRight';
 export { default as curry } from './curry/curry';
 export { default as curryRight } from './curryRight/curryRight';
 export { default as identity } from './identity/identity';
+export { default as inst } from './inst/inst';
+export { default as negate } from './negate/negate';
+export { default as not } from './not/not';
+export { default as or } from './or/or';
 export { default as partial } from './partial/partial';
 export { default as partialRight } from './partialRight/partialRight';
+export { default as trim } from './trim/trim';
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "jest ./src",
     "check": "eslint ./src && flow ./src",
-    "build": "yarn check && babel src/ -d ./ --ignore **/*spec.js && yarn build:docs && yarn build:types",
+    "build": "npm run check && babel src/ -d ./ --ignore **/*spec.js && npm run build:docs && npm run build:types",
     "build:types": "flow-copy-source -v -i **/*spec.js src ./",
     "build:docs": "node ./scripts/docs"
   },

--- a/src/async/bimap/bimap.js
+++ b/src/async/bimap/bimap.js
@@ -5,14 +5,14 @@
  * @param leftFn {Function}
  * @param rightFn {Function}
  * @param p {Promise<T | never>}
- * @returns {Promise<T | never>}
+ * @returns {Promise<R | never>}
  */
-function bimap<T>(
-  leftFn: (Error) => any,
-  rightFn: (T) => any,
+function bimap<T, R>(
+  leftFn: (any) => any,
+  rightFn: (T) => R,
   p: Promise<T>
-): Promise<T> {
-  return p.then(rightFn, leftFn);
+): Promise<R> {
+  return p.then(rightFn, (e: any): Promise<R> => Promise.reject(leftFn(e)));
 }
 
 export default bimap;

--- a/src/async/bimap/bimap.spec.js
+++ b/src/async/bimap/bimap.spec.js
@@ -3,27 +3,37 @@
 import bimap from './bimap';
 
 describe('async/bimap', () => {
-  test('should only call left fn if promise rejects', async (): Promise<any> => {
-    const leftFn: Function = jest.fn();
+  test('should only call leftFn if promise rejects', (done: Function): Promise<any> => {
+    const expected: Error = new Error('error');
+    const leftFn: Function = jest.fn().mockImplementation((v: number): Error => expected);
     const rightFn: Function = jest.fn();
 
-    try {
-      await bimap(leftFn, rightFn, Promise.reject(1));
+    expect.assertions(3);
 
-      expect(leftFn).not.toHaveBeenCalled();
-    } catch (e) {
-      expect(e).not.toBeUndefined();
-      expect(rightFn).not.toHaveBeenCalled();
-    }
+    bimap(leftFn, rightFn, Promise.reject(3))
+      .then(done)
+      .catch((actual: Error) => {
+        expect(actual).toBe(expected);
+        expect(leftFn).toHaveBeenCalled();
+        expect(rightFn).not.toHaveBeenCalled();
+        done();
+      });
   });
 
-  test('should only call rightFn if promise resolves', async (): Promise<any> => {
+  test('should only call rightFn if promise resolves', (done: Function): Promise<any> => {
+    const expected: number = 6;
     const leftFn: Function = jest.fn();
-    const rightFn: Function = jest.fn();
+    const rightFn: Function = jest.fn().mockImplementation((v: number): number => expected);
 
-    await bimap(leftFn, rightFn, Promise.resolve(1));
+    expect.assertions(3);
 
-    expect(leftFn).not.toHaveBeenCalled();
-    expect(rightFn).toHaveBeenCalled();
+    bimap(leftFn, rightFn, Promise.resolve(1))
+      .then((actual: number) => {
+        expect(actual).toBe(expected);
+        expect(leftFn).not.toHaveBeenCalled();
+        expect(rightFn).toHaveBeenCalled();
+        done();
+      })
+      .catch(done);
   });
 });


### PR DESCRIPTION
Updated the return type to be Promise<R>, as it doesn't have to be the same type as the original promise.

I updated the test as it didn't look quite right – I think this method (.then, .catch rather than try/catch block) feels a bit more robust.  I will update other tests to use this as well (and have similar updates for type signatures) if you're happy with it.

Some additional updates happened to index files as a result of running `build`